### PR TITLE
Feat: add swagger and README.md

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ DB_NAME=tu-nombre-de-db
 DB_USER=tu-db-user
 DB_PASSWORD=tu-db-password
 DB_HOST=tu-db-host
+DB_PORT=5432

--- a/README.md
+++ b/README.md
@@ -1,0 +1,126 @@
+# Proyecto SGR
+
+Este proyecto es una aplicación Django que expone una API REST utilizando Django REST Framework (DRF). La aplicación está diseñada para gestionar diferentes entidades, como **Usuarios**, **Proyectos**, **Roles**, **Rubros**, entre otros. Además, la documentación de la API está disponible a través de **Swagger**.
+
+## Requisitos
+
+- Python 3.8 o superior
+- pip (gestor de paquetes de Python)
+- Virtualenv (opcional, pero recomendado para gestionar entornos virtuales)
+
+## Pasos para ejecutar el proyecto
+
+### 1. Clonar el repositorio
+
+Si aún no has clonado el repositorio, puedes hacerlo con el siguiente comando:
+
+```bash
+git clone https://github.com/juanF18/SGR-Backend
+cd SGR-Backend
+```
+
+### 2. Crear un entorno virtual (opcional pero recomendado)
+
+Es recomendable crear un entorno virtual para gestionar las dependencias de este proyecto de manera aislada. Si tienes `virtualenv` instalado, puedes crear y activar el entorno virtual de la siguiente manera:
+
+```bash
+# Crear el entorno virtual
+python -m venv venv
+
+# Activar el entorno virtual
+# En Windows:
+venv\Scripts\activate
+# En Mac/Linux:
+source venv/bin/activate
+```
+
+### 3. Instalar las dependencias
+
+Una vez dentro del entorno virtual, instala las dependencias del proyecto usando `pip`:
+
+```bash
+pip install -r requirements.txt
+```
+
+El archivo `requirements.txt` contiene todas las dependencias necesarias para ejecutar el proyecto, como Django, Django REST Framework, djangorestframework-simplejwt, drf-yasg para la documentación Swagger, entre otras.
+
+### 4. Ejecutar las migraciones
+
+Si es la primera vez que ejecutas el proyecto, debes aplicar las migraciones de la base de datos para crear las tablas necesarias.
+
+```bash
+python manage.py migrate
+```
+
+### 5. Crear un superusuario (opcional)
+
+Si deseas acceder al panel de administración de Django (por ejemplo, para crear usuarios manualmente), puedes crear un superusuario:
+
+```bash
+python manage.py createsuperuser
+```
+
+Sigue las instrucciones en la terminal para ingresar el nombre de usuario, correo electrónico y contraseña.
+
+### 6. Ejecutar el servidor de desarrollo
+
+Ahora puedes ejecutar el servidor de desarrollo de Django para comenzar a trabajar con la API:
+
+```bash
+python manage.py runserver
+```
+
+Esto iniciará el servidor de desarrollo en `http://127.0.0.1:8000/`.
+
+### 7. Acceder a la documentación Swagger
+
+Una vez que el servidor esté en funcionamiento, puedes acceder a la documentación interactiva de la API a través de Swagger. Para hacerlo, simplemente abre tu navegador web y visita la siguiente URL:
+
+```
+http://127.0.0.1:8000/swagger/
+```
+
+Aquí podrás ver todos los endpoints de la API, realizar pruebas de las solicitudes y visualizar los detalles de cada uno de ellos.
+
+### 8. Realizar peticiones a la API
+
+La API está diseñada para realizar operaciones CRUD (Crear, Leer, Actualizar, Eliminar) sobre las diferentes entidades. Puedes interactuar con estos endpoints utilizando herramientas como **Postman**, **Insomnia**, o directamente desde Swagger.
+
+## Estructura del proyecto
+
+La estructura básica del proyecto es la siguiente:
+
+```
+SGR-Backend/
+│
+├── core/                  # Contiene las aplicaciones principales (Usuarios, Proyectos, etc.)
+│   ├── users/             # Gestión de usuarios
+│   ├── roles/             # Roles de usuario
+│   ├── rubros/            # Rubros relacionados con los proyectos
+│   └── activities/        # Actividades relacionadas con los proyectos
+│
+├── sgr/           # Configuración principal de Django
+│   ├── settings.py        # Configuración del proyecto
+│   ├── urls.py            # Enlaces de URLs de la API
+│   └── wsgi.py            # Archivo de entrada para el servidor WSGI
+│
+├── manage.py              # Script principal para administrar el proyecto Django
+├── requirements.txt       # Lista de dependencias del proyecto
+└── .env                   # Variables de entorno para la configuración (no se debe subir a GitHub)
+```
+
+## Endpoints disponibles
+
+Una vez que el servidor esté en funcionamiento, puedes consultar los siguientes endpoints a través de la documentación Swagger:
+
+- `GET /users/` - Obtener todos los usuarios.
+- `POST /users/` - Crear un nuevo usuario.
+- `GET /users/{id}/` - Obtener un usuario específico por ID.
+- `POST /login/` - Iniciar sesión y obtener un token JWT.
+- (y muchos más endpoints dependiendo de las entidades en tu proyecto).
+
+## Consideraciones adicionales
+
+- Asegúrate de que las dependencias estén instaladas correctamente y que el archivo `.env` esté configurado antes de ejecutar el proyecto.
+- La documentación de la API se genera automáticamente utilizando **Swagger** y es accesible en `http://127.0.0.1:8000/swagger/`.
+- Asegúrate de que la base de datos y otras configuraciones (como los servicios de correo) estén correctamente configuradas en el archivo `.env`.

--- a/core/activities/views.py
+++ b/core/activities/views.py
@@ -1,16 +1,61 @@
-from django.shortcuts import render
 from rest_framework import status
 from rest_framework.response import Response
-from .models import Activity
 from rest_framework.views import APIView
+from .models import Activity
 from .serializers import ActivitySerializer
 from core.projects.models import Project
 from core.rubros.models import Rubro
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
+
+# Parámetros para el cuerpo de la solicitud POST (Activity)
+activity_request_body = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        "name": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Nombre de la actividad"
+        ),
+        "description": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Descripción de la actividad"
+        ),
+        "type": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Tipo de actividad"
+        ),
+        "start_date": openapi.Schema(
+            type=openapi.TYPE_STRING,
+            format=openapi.FORMAT_DATE,
+            description="Fecha de inicio de la actividad",
+        ),
+        "end_date": openapi.Schema(
+            type=openapi.TYPE_STRING,
+            format=openapi.FORMAT_DATE,
+            description="Fecha de fin de la actividad",
+        ),
+        "state": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Estado de la actividad"
+        ),
+        "project_id": openapi.Schema(
+            type=openapi.TYPE_INTEGER, description="ID del proyecto relacionado"
+        ),
+        "rubro_id": openapi.Schema(
+            type=openapi.TYPE_INTEGER, description="ID del rubro relacionado"
+        ),
+    },
+)
 
 
-# Create your views here.
 class ActivityView(APIView):
-
+    # Documentar el método GET para obtener actividades
+    @swagger_auto_schema(
+        operation_description="Obtener todas las actividades",
+        responses={
+            200: openapi.Response(
+                description="Actividades recuperadas correctamente",
+                schema=ActivitySerializer(many=True),
+            ),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request):
         try:
             data = Activity.objects.all()
@@ -28,6 +73,20 @@ class ActivityView(APIView):
             }
             return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+    # Documentar el método POST para crear una nueva actividad
+    @swagger_auto_schema(
+        operation_description="Crear una nueva actividad",
+        request_body=activity_request_body,
+        responses={
+            201: openapi.Response(
+                description="Actividad creada correctamente", schema=ActivitySerializer
+            ),
+            400: openapi.Response(
+                description="Error en los datos de entrada (por ejemplo, Proyecto o Rubro no existe)"
+            ),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def post(self, request):
         try:
             data = request.data
@@ -49,7 +108,6 @@ class ActivityView(APIView):
                 "status": status.HTTP_201_CREATED,
                 "activity": activity_serializer.data,
             }
-
             return Response(response, status=status.HTTP_201_CREATED)
         except Project.DoesNotExist:
             response = {
@@ -72,14 +130,26 @@ class ActivityView(APIView):
 
 
 class ActivityDetailView(APIView):
-
+    # Documentar el método GET para obtener el detalle de una actividad
+    @swagger_auto_schema(
+        operation_description="Obtener los detalles de una actividad",
+        responses={
+            200: openapi.Response(
+                description="Actividad recuperada correctamente",
+                schema=ActivitySerializer,
+            ),
+            400: openapi.Response(description="Actividad no encontrada"),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request, pk):
         try:
             activity = Activity.objects.get(id=pk)
+            activity_serializer = ActivitySerializer(activity)
             response = {
                 "message": "Activity retrieved successfully",
                 "status": status.HTTP_200_OK,
-                "activity": activity,
+                "activity": activity_serializer.data,
             }
             return Response(response, status=status.HTTP_200_OK)
         except Activity.DoesNotExist:

--- a/core/cdps/views.py
+++ b/core/cdps/views.py
@@ -1,14 +1,56 @@
-from django.shortcuts import render
 from rest_framework import status
 from rest_framework.response import Response
 from .models import Cdps
 from rest_framework.views import APIView
 from .serializers import CdpsSerializer
 from core.rubros.models import Rubro
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
+
+# Definir el cuerpo de la solicitud para el POST
+cdps_request_body = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        "number": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Número del CDP"
+        ),
+        "expedition_date": openapi.Schema(
+            type=openapi.TYPE_STRING,
+            format=openapi.FORMAT_DATE,
+            description="Fecha de expedición",
+        ),
+        "amount": openapi.Schema(type=openapi.TYPE_NUMBER, description="Monto del CDP"),
+        "description": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Descripción del CDP"
+        ),
+        "is_generated": openapi.Schema(
+            type=openapi.TYPE_BOOLEAN, description="Indica si el CDP está generado"
+        ),
+        "is_canceled": openapi.Schema(
+            type=openapi.TYPE_BOOLEAN, description="Indica si el CDP está cancelado"
+        ),
+        "document": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Documento asociado al CDP"
+        ),
+        "rubro_id": openapi.Schema(
+            type=openapi.TYPE_INTEGER, description="ID del Rubro asociado al CDP"
+        ),
+    },
+)
 
 
-# Create your views here.
 class CdpsView(APIView):
+    # Documentar el método GET para obtener todos los CDPs
+    @swagger_auto_schema(
+        operation_description="Obtener todos los CDPs",
+        responses={
+            200: openapi.Response(
+                description="CDPs recuperados correctamente",
+                schema=CdpsSerializer(many=True),
+            ),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request):
         try:
             data = Cdps.objects.all()
@@ -26,6 +68,20 @@ class CdpsView(APIView):
             }
             return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+    # Documentar el método POST para crear un nuevo CDP
+    @swagger_auto_schema(
+        operation_description="Crear un nuevo CDP",
+        request_body=cdps_request_body,
+        responses={
+            201: openapi.Response(
+                description="CDP creado correctamente", schema=CdpsSerializer
+            ),
+            400: openapi.Response(
+                description="Error en los datos de entrada (por ejemplo, Rubro no existe)"
+            ),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def post(self, request):
         try:
             data = request.data
@@ -46,7 +102,6 @@ class CdpsView(APIView):
                 "status": status.HTTP_201_CREATED,
                 "cdps": cdps_serializer.data,
             }
-
             return Response(response, status=status.HTTP_201_CREATED)
         except Exception as e:
             response = {
@@ -57,6 +112,17 @@ class CdpsView(APIView):
 
 
 class CdpsDetailView(APIView):
+    # Documentar el método GET para obtener el detalle de un CDP
+    @swagger_auto_schema(
+        operation_description="Obtener los detalles de un CDP",
+        responses={
+            200: openapi.Response(
+                description="CDP recuperado correctamente", schema=CdpsSerializer
+            ),
+            400: openapi.Response(description="CDP no encontrado"),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request, id):
         try:
             cdps = Cdps.objects.get(id=id)

--- a/core/comments/views.py
+++ b/core/comments/views.py
@@ -1,15 +1,41 @@
-from django.shortcuts import render
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from .models import Comment
 from .serializers import CommentSerializer
 from core.users.models import User
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
+
+# Definir el cuerpo de la solicitud para el POST en CommentView
+comment_request_body = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        "comment_text": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Texto del comentario"
+        ),
+        "user_id": openapi.Schema(
+            type=openapi.TYPE_INTEGER,
+            description="ID del usuario que realiza el comentario",
+        ),
+    },
+)
 
 
-# Create your views here.
 class CommentView(APIView):
-
+    # Documentar el método POST para crear un nuevo comentario
+    @swagger_auto_schema(
+        operation_description="Crear un nuevo comentario",
+        request_body=comment_request_body,
+        responses={
+            201: openapi.Response(
+                description="Comentario creado correctamente", schema=CommentSerializer
+            ),
+            400: openapi.Response(description="El campo 'comment_text' es requerido"),
+            404: openapi.Response(description="Usuario no encontrado"),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def post(self, request):
         try:
             data = request.data
@@ -48,7 +74,18 @@ class CommentView(APIView):
 
 
 class CommentDetailView(APIView):
-
+    # Documentar el método GET para obtener los detalles de un comentario
+    @swagger_auto_schema(
+        operation_description="Obtener los detalles de un comentario",
+        responses={
+            200: openapi.Response(
+                description="Comentario recuperado correctamente",
+                schema=CommentSerializer,
+            ),
+            404: openapi.Response(description="Comentario no encontrado"),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request, pk):
         try:
             comment = Comment.objects.get(id=pk)
@@ -74,7 +111,20 @@ class CommentDetailView(APIView):
 
 
 class CommentUserView(APIView):
-
+    # Documentar el método GET para obtener todos los comentarios de un usuario
+    @swagger_auto_schema(
+        operation_description="Obtener todos los comentarios de un usuario",
+        responses={
+            200: openapi.Response(
+                description="Comentarios recuperados correctamente",
+                schema=CommentSerializer(many=True),
+            ),
+            404: openapi.Response(
+                description="Comentarios no encontrados para este usuario"
+            ),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request, user_id):
         try:
             comments = Comment.objects.filter(user_id=user_id)

--- a/core/contracts/views.py
+++ b/core/contracts/views.py
@@ -1,14 +1,74 @@
-from django.shortcuts import render
 from rest_framework import status
 from rest_framework.response import Response
-from .models import Contract
 from rest_framework.views import APIView
+from .models import Contract
 from .serializers import ContractSerializer
 from core.cdps.models import Cdps
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
+
+# Definir el cuerpo de la solicitud para el POST en ContractView
+contract_request_body = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        "contract_number": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Número del contrato"
+        ),
+        "contracting_nit": openapi.Schema(
+            type=openapi.TYPE_STRING, description="NIT del contratante"
+        ),
+        "contracted_nit": openapi.Schema(
+            type=openapi.TYPE_STRING, description="NIT del contratado"
+        ),
+        "contracting_name": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Nombre del contratante"
+        ),
+        "start_date": openapi.Schema(
+            type=openapi.TYPE_STRING,
+            description="Fecha de inicio del contrato (formato: YYYY-MM-DD)",
+        ),
+        "end_date": openapi.Schema(
+            type=openapi.TYPE_STRING,
+            description="Fecha de finalización del contrato (formato: YYYY-MM-DD)",
+        ),
+        "contract_info": openapi.Schema(
+            type=openapi.TYPE_STRING,
+            description="Información adicional sobre el contrato",
+        ),
+        "amount": openapi.Schema(
+            type=openapi.TYPE_NUMBER, description="Monto del contrato"
+        ),
+        "supervisor_name": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Nombre del supervisor"
+        ),
+        "supervisor_identification": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Identificación del supervisor"
+        ),
+        "contract_url": openapi.Schema(
+            type=openapi.TYPE_STRING, description="URL del contrato"
+        ),
+        "observations": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Observaciones del contrato"
+        ),
+        "cpds_id": openapi.Schema(
+            type=openapi.TYPE_INTEGER, description="ID del CDPS relacionado"
+        ),
+    },
+)
 
 
-# Create your views here.
 class ContractView(APIView):
+    # Documentar el método GET para obtener todos los contratos
+    @swagger_auto_schema(
+        operation_description="Obtener todos los contratos",
+        responses={
+            200: openapi.Response(
+                description="Contratos recuperados correctamente",
+                schema=ContractSerializer(many=True),
+            ),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request):
         try:
             data = Contract.objects.all()
@@ -26,6 +86,18 @@ class ContractView(APIView):
             }
             return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+    # Documentar el método POST para crear un nuevo contrato
+    @swagger_auto_schema(
+        operation_description="Crear un nuevo contrato",
+        request_body=contract_request_body,
+        responses={
+            201: openapi.Response(
+                description="Contrato creado correctamente", schema=ContractSerializer
+            ),
+            400: openapi.Response(description="CDPS no encontrado"),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def post(self, request):
         try:
             data = request.data
@@ -68,6 +140,18 @@ class ContractView(APIView):
 
 
 class ContractDetailView(APIView):
+    # Documentar el método GET para obtener los detalles de un contrato
+    @swagger_auto_schema(
+        operation_description="Obtener los detalles de un contrato",
+        responses={
+            200: openapi.Response(
+                description="Contrato recuperado correctamente",
+                schema=ContractSerializer,
+            ),
+            400: openapi.Response(description="Contrato no encontrado"),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request, pk):
         try:
             contract = Contract.objects.get(id=pk)

--- a/core/counterparts/views.py
+++ b/core/counterparts/views.py
@@ -1,15 +1,44 @@
-from django.shortcuts import render
 from rest_framework import status
 from rest_framework.response import Response
-from .models import Counterpart
 from rest_framework.views import APIView
+from .models import Counterpart
 from .serializers import CounterpartSerializer
 from core.rubros.models import Rubro
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
+
+# Definir el cuerpo de la solicitud para el POST en CounterpartView
+counterpart_request_body = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        "name": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Nombre de la contraparte"
+        ),
+        "value_species": openapi.Schema(
+            type=openapi.TYPE_NUMBER, description="Valor en especie"
+        ),
+        "value_chash": openapi.Schema(
+            type=openapi.TYPE_NUMBER, description="Valor en efectivo"
+        ),
+        "rubro_id": openapi.Schema(
+            type=openapi.TYPE_INTEGER, description="ID del rubro relacionado"
+        ),
+    },
+)
 
 
-# Create your views here.
 class CounterpartView(APIView):
-
+    # Documentar el método GET para obtener todas las contrapartes
+    @swagger_auto_schema(
+        operation_description="Obtener todas las contrapartes",
+        responses={
+            200: openapi.Response(
+                description="Contrapartes recuperadas correctamente",
+                schema=CounterpartSerializer(many=True),
+            ),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request):
         try:
             data = Counterpart.objects.all()
@@ -27,6 +56,19 @@ class CounterpartView(APIView):
             }
             return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+    # Documentar el método POST para crear una nueva contraparte
+    @swagger_auto_schema(
+        operation_description="Crear una nueva contraparte",
+        request_body=counterpart_request_body,
+        responses={
+            201: openapi.Response(
+                description="Contraparte creada correctamente",
+                schema=CounterpartSerializer,
+            ),
+            400: openapi.Response(description="Rubro no encontrado"),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def post(self, request):
         try:
             data = request.data
@@ -60,11 +102,22 @@ class CounterpartView(APIView):
 
 
 class CounterpartDetailView(APIView):
-
+    # Documentar el método GET para obtener los detalles de una contraparte
+    @swagger_auto_schema(
+        operation_description="Obtener los detalles de una contraparte",
+        responses={
+            200: openapi.Response(
+                description="Contraparte recuperada correctamente",
+                schema=CounterpartSerializer,
+            ),
+            400: openapi.Response(description="Contraparte no encontrada"),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request, id):
         try:
-            data = Counterpart.objects.get(id=id)
-            counterpart_serializer = CounterpartSerializer(data, many=False)
+            counterpart = Counterpart.objects.get(id=id)
+            counterpart_serializer = CounterpartSerializer(counterpart, many=False)
             response = {
                 "message": "Counterpart retrieved successfully",
                 "status": status.HTTP_200_OK,

--- a/core/detailContracts/views.py
+++ b/core/detailContracts/views.py
@@ -4,10 +4,51 @@ from rest_framework import status
 from .models import DetailContract
 from .serializers import DetailContractSerializer
 from core.contracts.models import Contract
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
+
+# Definir el cuerpo de la solicitud para el POST en DetailContractView
+detail_contract_request_body = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        "description": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Descripción del contrato"
+        ),
+        "start_date": openapi.Schema(
+            type=openapi.TYPE_STRING,
+            format=openapi.FORMAT_DATETIME,
+            description="Fecha de inicio",
+        ),
+        "end_date": openapi.Schema(
+            type=openapi.TYPE_STRING,
+            format=openapi.FORMAT_DATETIME,
+            description="Fecha de fin",
+        ),
+        "state": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Estado del contrato"
+        ),
+        "task_id": openapi.Schema(
+            type=openapi.TYPE_INTEGER, description="ID de la tarea relacionada"
+        ),
+        "contract_id": openapi.Schema(
+            type=openapi.TYPE_INTEGER, description="ID del contrato relacionado"
+        ),
+    },
+)
 
 
 class DetailContractView(APIView):
-
+    # Documentar el método GET para obtener todos los detalles de contratos
+    @swagger_auto_schema(
+        operation_description="Obtener todos los detalles de los contratos",
+        responses={
+            200: openapi.Response(
+                description="Detalles de contratos recuperados correctamente",
+                schema=DetailContractSerializer(many=True),
+            ),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request):
         try:
             data = DetailContract.objects.all()
@@ -25,6 +66,19 @@ class DetailContractView(APIView):
             }
             return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+    # Documentar el método POST para crear un detalle de contrato
+    @swagger_auto_schema(
+        operation_description="Crear un detalle de contrato",
+        request_body=detail_contract_request_body,
+        responses={
+            201: openapi.Response(
+                description="Detalle de contrato creado correctamente",
+                schema=DetailContractSerializer,
+            ),
+            400: openapi.Response(description="Contrato no encontrado"),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def post(self, request):
         try:
             data = request.data
@@ -62,7 +116,18 @@ class DetailContractView(APIView):
 
 
 class DetailContractDetailView(APIView):
-
+    # Documentar el método GET para obtener un detalle de contrato por ID
+    @swagger_auto_schema(
+        operation_description="Obtener detalles de un contrato específico por ID",
+        responses={
+            200: openapi.Response(
+                description="Detalle de contrato recuperado correctamente",
+                schema=DetailContractSerializer,
+            ),
+            400: openapi.Response(description="Detalle de contrato no encontrado"),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request, id):
         try:
             data = DetailContract.objects.get(id=id)

--- a/core/entities/views.py
+++ b/core/entities/views.py
@@ -3,10 +3,48 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from .models import Entity
 from .serializers import EntitySerializer, EntityValidator
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
 
 
-# Create your views here.
+# Definir el cuerpo de la solicitud para el POST y PUT en EntityView
+entity_request_body = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        "name": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Nombre de la entidad"
+        ),
+        "description": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Descripción de la entidad"
+        ),
+        "address": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Dirección de la entidad"
+        ),
+        "phone": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Teléfono de la entidad"
+        ),
+        "email": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Correo electrónico de la entidad"
+        ),
+        "city": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Ciudad de la entidad"
+        ),
+    },
+)
+
+
 class EntityView(APIView):
+    # Documentar el método GET para obtener todas las entidades
+    @swagger_auto_schema(
+        operation_description="Obtener todas las entidades",
+        responses={
+            200: openapi.Response(
+                description="Entidades recuperadas correctamente",
+                schema=EntitySerializer(many=True),
+            ),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request):
         try:
             entities = Entity.objects.all()
@@ -24,6 +62,18 @@ class EntityView(APIView):
             }
             return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+    # Documentar el método POST para crear una entidad
+    @swagger_auto_schema(
+        operation_description="Crear una nueva entidad",
+        request_body=entity_request_body,
+        responses={
+            201: openapi.Response(
+                description="Entidad creada correctamente", schema=EntitySerializer
+            ),
+            400: openapi.Response(description="Datos inválidos"),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def post(self, request):
         try:
             data = request.data
@@ -55,6 +105,18 @@ class EntityView(APIView):
             }
             return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+    # Documentar el método PUT para actualizar una entidad
+    @swagger_auto_schema(
+        operation_description="Actualizar una entidad existente",
+        request_body=entity_request_body,
+        responses={
+            200: openapi.Response(
+                description="Entidad actualizada correctamente", schema=EntitySerializer
+            ),
+            404: openapi.Response(description="Entidad no encontrada"),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def put(self, request, id):
         try:
             entity = Entity.objects.get(id=id)
@@ -87,7 +149,17 @@ class EntityView(APIView):
 
 
 class EntityDetailView(APIView):
-
+    # Documentar el método GET para obtener una entidad específica por ID
+    @swagger_auto_schema(
+        operation_description="Obtener una entidad específica por ID",
+        responses={
+            200: openapi.Response(
+                description="Entidad recuperada correctamente", schema=EntitySerializer
+            ),
+            404: openapi.Response(description="Entidad no encontrada"),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request, id):
         try:
             entity = Entity.objects.get(id=id)

--- a/core/items/views.py
+++ b/core/items/views.py
@@ -1,15 +1,56 @@
-from django.shortcuts import render
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
 from .models import Item
 from .serializers import ItemSerializer
 from core.rubros.models import Rubro
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
 
 
-# Create your views here.
+# Definir el cuerpo de la solicitud para el POST en ItemView
+item_request_body = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        "description": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Descripción del item"
+        ),
+        "justificacion": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Justificación del item"
+        ),
+        "quantity": openapi.Schema(
+            type=openapi.TYPE_INTEGER, description="Cantidad del item"
+        ),
+        "unit_value": openapi.Schema(
+            type=openapi.TYPE_NUMBER,
+            format=openapi.FORMAT_FLOAT,
+            description="Valor unitario del item",
+        ),
+        "total_value": openapi.Schema(
+            type=openapi.TYPE_NUMBER,
+            format=openapi.FORMAT_FLOAT,
+            description="Valor total del item",
+        ),
+        "rubro_id": openapi.Schema(
+            type=openapi.TYPE_INTEGER,
+            description="ID del rubro relacionado con el item",
+        ),
+    },
+)
+
+
 class ItemView(APIView):
-
+    # Documentar el método GET para obtener todos los items
+    @swagger_auto_schema(
+        operation_description="Obtener todos los items",
+        responses={
+            200: openapi.Response(
+                description="Items recuperados correctamente",
+                schema=ItemSerializer(many=True),
+            ),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request):
         try:
             items = Item.objects.all()
@@ -27,6 +68,18 @@ class ItemView(APIView):
             }
             return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+    # Documentar el método POST para crear un item
+    @swagger_auto_schema(
+        operation_description="Crear un nuevo item",
+        request_body=item_request_body,
+        responses={
+            201: openapi.Response(
+                description="Item creado correctamente", schema=ItemSerializer
+            ),
+            400: openapi.Response(description="Rubro no existe"),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def post(self, request):
         try:
             data = request.data
@@ -61,7 +114,17 @@ class ItemView(APIView):
 
 
 class ItemDetailView(APIView):
-
+    # Documentar el método GET para obtener un item específico por ID
+    @swagger_auto_schema(
+        operation_description="Obtener un item específico por ID",
+        responses={
+            200: openapi.Response(
+                description="Item recuperado correctamente", schema=ItemSerializer
+            ),
+            400: openapi.Response(description="Item no encontrado"),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request, item_id):
         try:
             item = Item.objects.get(id=item_id)

--- a/core/movements/views.py
+++ b/core/movements/views.py
@@ -1,14 +1,49 @@
-from django.shortcuts import render
 from rest_framework import status
 from rest_framework.response import Response
 from .models import Movement
 from rest_framework.views import APIView
 from .serializers import MovementSerializer
 from core.contracts.models import Contract
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
 
 
-# Create your views here.
+# Definir el cuerpo de la solicitud para el POST en MovementView
+movement_request_body = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        "amount": openapi.Schema(
+            type=openapi.TYPE_NUMBER,
+            format=openapi.FORMAT_FLOAT,
+            description="Monto del movimiento",
+        ),
+        "description": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Descripción del movimiento"
+        ),
+        "type": openapi.Schema(
+            type=openapi.TYPE_STRING,
+            description="Tipo de movimiento (ingreso, egreso, etc.)",
+        ),
+        "contract_id": openapi.Schema(
+            type=openapi.TYPE_INTEGER,
+            description="ID del contrato relacionado con el movimiento",
+        ),
+    },
+)
+
+
 class MovementView(APIView):
+    # Documentar el método GET para obtener todos los movimientos
+    @swagger_auto_schema(
+        operation_description="Obtener todos los movimientos",
+        responses={
+            200: openapi.Response(
+                description="Movimientos recuperados correctamente",
+                schema=MovementSerializer(many=True),
+            ),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request):
         try:
             data = Movement.objects.all()
@@ -26,6 +61,18 @@ class MovementView(APIView):
             }
             return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+    # Documentar el método POST para crear un movimiento
+    @swagger_auto_schema(
+        operation_description="Crear un nuevo movimiento",
+        request_body=movement_request_body,
+        responses={
+            201: openapi.Response(
+                description="Movimiento creado correctamente", schema=MovementSerializer
+            ),
+            400: openapi.Response(description="Contrato no encontrado"),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def post(self, request):
         try:
             data = request.data
@@ -59,6 +106,18 @@ class MovementView(APIView):
 
 
 class MovementDetailView(APIView):
+    # Documentar el método GET para obtener un movimiento específico por ID
+    @swagger_auto_schema(
+        operation_description="Obtener un movimiento específico por ID",
+        responses={
+            200: openapi.Response(
+                description="Movimiento recuperado correctamente",
+                schema=MovementSerializer,
+            ),
+            400: openapi.Response(description="Movimiento no encontrado"),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request, id):
         try:
             movement = Movement.objects.get(id=id)

--- a/core/persons/views.py
+++ b/core/persons/views.py
@@ -1,14 +1,62 @@
-from django.shortcuts import render
 from rest_framework import status
 from rest_framework.response import Response
 from .models import Person
 from rest_framework.views import APIView
 from .serializers import PersonSerializer
 from core.rubros.models import Rubro
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
 
 
-# Create your views here.
+# Definir el cuerpo de la solicitud para el POST en PersonView
+person_request_body = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        "job_title": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Título del trabajo de la persona"
+        ),
+        "dedication": openapi.Schema(
+            type=openapi.TYPE_STRING,
+            description="Dedicación de la persona (Tiempo completo, medio tiempo, etc.)",
+        ),
+        "weeks": openapi.Schema(
+            type=openapi.TYPE_INTEGER, description="Número de semanas trabajadas"
+        ),
+        "fees": openapi.Schema(
+            type=openapi.TYPE_NUMBER,
+            format=openapi.FORMAT_FLOAT,
+            description="Honorarios",
+        ),
+        "value_hour": openapi.Schema(
+            type=openapi.TYPE_NUMBER,
+            format=openapi.FORMAT_FLOAT,
+            description="Valor por hora de trabajo",
+        ),
+        "total": openapi.Schema(
+            type=openapi.TYPE_NUMBER,
+            format=openapi.FORMAT_FLOAT,
+            description="Total por el trabajo realizado",
+        ),
+        "rubro_id": openapi.Schema(
+            type=openapi.TYPE_INTEGER,
+            description="ID del rubro relacionado con la persona",
+        ),
+    },
+)
+
+
 class PersonView(APIView):
+    # Documentar el método GET para obtener todas las personas
+    @swagger_auto_schema(
+        operation_description="Obtener todas las personas",
+        responses={
+            200: openapi.Response(
+                description="Personas recuperadas correctamente",
+                schema=PersonSerializer(many=True),
+            ),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request):
         try:
             data = Person.objects.all()
@@ -26,6 +74,18 @@ class PersonView(APIView):
             }
             return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+    # Documentar el método POST para crear una nueva persona
+    @swagger_auto_schema(
+        operation_description="Crear una nueva persona",
+        request_body=person_request_body,
+        responses={
+            201: openapi.Response(
+                description="Persona creada correctamente", schema=PersonSerializer
+            ),
+            404: openapi.Response(description="Rubro no encontrado"),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def post(self, request):
         try:
             data = request.data
@@ -62,6 +122,17 @@ class PersonView(APIView):
 
 
 class PersonDetailView(APIView):
+    # Documentar el método GET para obtener una persona específica por ID
+    @swagger_auto_schema(
+        operation_description="Obtener una persona específica por ID",
+        responses={
+            200: openapi.Response(
+                description="Persona recuperada correctamente", schema=PersonSerializer
+            ),
+            404: openapi.Response(description="Persona no encontrada"),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request, id):
         try:
             person = Person.objects.get(id=id)

--- a/core/projects/models.py
+++ b/core/projects/models.py
@@ -1,8 +1,5 @@
 from django.db import models
-<<<<<<< HEAD
 from core.entities.models import Entity
-=======
->>>>>>> develop
 
 
 # Create your models here.
@@ -18,12 +15,9 @@ class Project(models.Model):
     file_activities_url = models.CharField(
         "file_activities_url", max_length=150, blank=True, null=True
     )
-<<<<<<< HEAD
     entity_id = models.ForeignKey(
         Entity, on_delete=models.SET_NULL, null=True, blank=True
     )
-=======
->>>>>>> develop
     created_at = models.DateTimeField("created_at", auto_now_add=True)
     updated_at = models.DateTimeField("updated_at", auto_now=True)
     deleted_at = models.DateTimeField("deleted_at", blank=True, null=True)

--- a/core/projects/views.py
+++ b/core/projects/views.py
@@ -1,15 +1,64 @@
-from rest_framework import viewsets
-from .models import Project
-from .serializers import ProjectSerializer, ProjectValidator
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from .models import Project
+from .serializers import ProjectSerializer, ProjectValidator
 from core.entities.models import Entity
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
 
 
-# Create your views here.
+# Definir el cuerpo de la solicitud para el POST en ProjectView
+project_request_body = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        "name": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Nombre del proyecto"
+        ),
+        "description": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Descripción del proyecto"
+        ),
+        "value": openapi.Schema(
+            type=openapi.TYPE_NUMBER,
+            format=openapi.FORMAT_FLOAT,
+            description="Valor del proyecto",
+        ),
+        "start_date": openapi.Schema(
+            type=openapi.TYPE_STRING,
+            format=openapi.FORMAT_DATETIME,
+            description="Fecha de inicio del proyecto",
+        ),
+        "end_date": openapi.Schema(
+            type=openapi.TYPE_STRING,
+            format=openapi.FORMAT_DATETIME,
+            description="Fecha de finalización del proyecto",
+        ),
+        "file_budget_url": openapi.Schema(
+            type=openapi.TYPE_STRING, description="URL del archivo del presupuesto"
+        ),
+        "file_activities_url": openapi.Schema(
+            type=openapi.TYPE_STRING, description="URL del archivo de actividades"
+        ),
+        "entity_id": openapi.Schema(
+            type=openapi.TYPE_INTEGER,
+            description="ID de la entidad asociada al proyecto",
+        ),
+    },
+)
+
+
 class ProjectView(APIView):
-
+    # Documentar el método GET para obtener todos los proyectos
+    @swagger_auto_schema(
+        operation_description="Obtener todos los proyectos",
+        responses={
+            200: openapi.Response(
+                description="Proyectos recuperados correctamente",
+                schema=ProjectSerializer(many=True),
+            ),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request):
         try:
             data = Project.objects.all()
@@ -27,6 +76,20 @@ class ProjectView(APIView):
             }
             return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+    # Documentar el método POST para crear un nuevo proyecto
+    @swagger_auto_schema(
+        operation_description="Crear un nuevo proyecto",
+        request_body=project_request_body,
+        responses={
+            201: openapi.Response(
+                description="Proyecto creado correctamente", schema=ProjectSerializer
+            ),
+            400: openapi.Response(
+                description="Datos inválidos para la creación del proyecto"
+            ),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def post(self, request):
         try:
             data = request.data
@@ -65,10 +128,21 @@ class ProjectView(APIView):
 
 
 class ProjectDetail(APIView):
-
+    # Documentar el método GET para obtener un proyecto específico por ID
+    @swagger_auto_schema(
+        operation_description="Obtener un proyecto específico por ID",
+        responses={
+            200: openapi.Response(
+                description="Proyecto recuperado correctamente",
+                schema=ProjectSerializer,
+            ),
+            404: openapi.Response(description="Proyecto no encontrado"),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request, id):
         try:
-            project = self.get_object(id)
+            project = Project.objects.get(id=id)
             project_serializer = ProjectSerializer(project, many=False)
             response = {
                 "message": "Project retrieved successfully",

--- a/core/roles/serializers.py
+++ b/core/roles/serializers.py
@@ -24,7 +24,7 @@ class RoleValidator(forms.Form):
 class RoleSerializer(serializers.ModelSerializer):
     class Meta:
         model = Role
-        fields = "__all__"
+        exclude = ["created_at", "updated_at", "deleted_at"]
 
     def to_representation(self, instance):
         representation = super().to_representation(instance)

--- a/core/roles/views.py
+++ b/core/roles/views.py
@@ -3,11 +3,31 @@ from rest_framework.response import Response
 from rest_framework import status
 from .models import Role
 from .serializers import RoleSerializer, RoleValidator
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
 
 
-# Create your views here.
+# Definir el cuerpo de la solicitud para el POST y PUT en RoleView
+role_request_body = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        "name": openapi.Schema(type=openapi.TYPE_STRING, description="Nombre del rol"),
+    },
+)
+
+
 class RoleView(APIView):
-
+    # Documentar el método GET para obtener todos los roles
+    @swagger_auto_schema(
+        operation_description="Obtener todos los roles",
+        responses={
+            200: openapi.Response(
+                description="Roles recuperados correctamente",
+                schema=RoleSerializer(many=True),
+            ),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request):
         try:
             data = Role.objects.all()
@@ -25,6 +45,20 @@ class RoleView(APIView):
             }
             return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+    # Documentar el método POST para crear un nuevo rol
+    @swagger_auto_schema(
+        operation_description="Crear un nuevo rol",
+        request_body=role_request_body,
+        responses={
+            201: openapi.Response(
+                description="Rol creado correctamente", schema=RoleSerializer
+            ),
+            400: openapi.Response(
+                description="Datos inválidos para la creación del rol"
+            ),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def post(self, request):
         try:
             data = request.data
@@ -53,6 +87,21 @@ class RoleView(APIView):
             }
             return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+    # Documentar el método PUT para actualizar un rol existente
+    @swagger_auto_schema(
+        operation_description="Actualizar un rol existente",
+        request_body=role_request_body,
+        responses={
+            200: openapi.Response(
+                description="Rol actualizado correctamente", schema=RoleSerializer
+            ),
+            400: openapi.Response(
+                description="Datos inválidos para la actualización del rol"
+            ),
+            404: openapi.Response(description="Rol no encontrado"),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def put(self, request, id):
         try:
             data = request.data
@@ -80,9 +129,25 @@ class RoleView(APIView):
             }
             return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+    def get_object(self, id):
+        try:
+            return Role.objects.get(id=id)
+        except Role.DoesNotExist:
+            return None
+
 
 class RoleDetailView(APIView):
-
+    # Documentar el método GET para obtener un rol específico por ID
+    @swagger_auto_schema(
+        operation_description="Obtener un rol específico por ID",
+        responses={
+            200: openapi.Response(
+                description="Rol recuperado correctamente", schema=RoleSerializer
+            ),
+            404: openapi.Response(description="Rol no encontrado"),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request, id):
         try:
             role = Role.objects.get(id=id)
@@ -99,3 +164,9 @@ class RoleDetailView(APIView):
                 "status": status.HTTP_404_NOT_FOUND,
             }
             return Response(response, status=status.HTTP_404_NOT_FOUND)
+        except Exception as e:
+            response = {
+                "message": f"Error retrieving role: {str(e)}",
+                "status": status.HTTP_500_INTERNAL_SERVER_ERROR,
+            }
+            return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/core/travels/views.py
+++ b/core/travels/views.py
@@ -1,15 +1,57 @@
-from django.shortcuts import render
 from rest_framework import status
 from rest_framework.response import Response
 from .models import Travel
 from rest_framework.views import APIView
 from .serializers import TravelSerializer
 from core.rubros.models import Rubro
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
 
 
-# Create your views here.
+# Definir el cuerpo de la solicitud para el POST de Travel
+travel_request_body = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        "origin": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Origen del viaje"
+        ),
+        "destination": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Destino del viaje"
+        ),
+        "transport": openapi.Schema(
+            type=openapi.TYPE_STRING, description="Medio de transporte utilizado"
+        ),
+        "quantity": openapi.Schema(
+            type=openapi.TYPE_INTEGER, description="Cantidad de unidades"
+        ),
+        "cant_persons": openapi.Schema(
+            type=openapi.TYPE_INTEGER, description="Número de personas"
+        ),
+        "cant_days": openapi.Schema(
+            type=openapi.TYPE_INTEGER, description="Número de días"
+        ),
+        "total": openapi.Schema(
+            type=openapi.TYPE_NUMBER, description="Total del viaje"
+        ),
+        "rubro_id": openapi.Schema(
+            type=openapi.TYPE_INTEGER, description="ID del Rubro asociado al viaje"
+        ),
+    },
+)
+
+
 class TravelView(APIView):
-
+    # Documentar el método GET para obtener todos los viajes
+    @swagger_auto_schema(
+        operation_description="Obtener todos los viajes",
+        responses={
+            200: openapi.Response(
+                description="Viajes recuperados correctamente",
+                schema=TravelSerializer(many=True),
+            ),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request):
         try:
             data = Travel.objects.all()
@@ -27,6 +69,18 @@ class TravelView(APIView):
             }
             return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+    # Documentar el método POST para crear un nuevo viaje
+    @swagger_auto_schema(
+        operation_description="Crear un nuevo viaje",
+        request_body=travel_request_body,
+        responses={
+            201: openapi.Response(
+                description="Viaje creado correctamente", schema=TravelSerializer
+            ),
+            400: openapi.Response(description="Rubro no encontrado"),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def post(self, request):
         try:
             data = request.data
@@ -47,7 +101,6 @@ class TravelView(APIView):
                 "status": status.HTTP_201_CREATED,
                 "travel": travel_serializer.data,
             }
-
             return Response(response, status=status.HTTP_201_CREATED)
         except Rubro.DoesNotExist:
             response = {
@@ -64,7 +117,17 @@ class TravelView(APIView):
 
 
 class TravelDetailView(APIView):
-
+    # Documentar el método GET para obtener un viaje específico por ID
+    @swagger_auto_schema(
+        operation_description="Obtener un viaje específico por ID",
+        responses={
+            200: openapi.Response(
+                description="Viaje recuperado correctamente", schema=TravelSerializer
+            ),
+            400: openapi.Response(description="Viaje no encontrado"),
+            500: openapi.Response(description="Error interno del servidor"),
+        },
+    )
     def get(self, request, pk):
         try:
             travel = Travel.objects.get(id=pk)

--- a/core/users/serializers.py
+++ b/core/users/serializers.py
@@ -7,12 +7,11 @@ from django.core import validators
 
 
 class UserSerializer(serializers.ModelSerializer):
-
     role = RoleSerializer(many=False)
 
     class Meta:
         model = User
-        fields = "__all__"
+        exclude = ["created_at", "updated_at", "deleted_at"]
 
     def validate_identification(self, email):
         if User.objects.filter(email=email).exists():

--- a/sgr/settings.py
+++ b/sgr/settings.py
@@ -47,32 +47,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     ## Third party apps
     "rest_framework",
-    "corsheaders",
-    ## Local apps
-    "core.roles",
-    "core.entities",
-    "core.users",
-    "core.comments",
-    "core.projects",
-    "core.rubros",
-    "core.items",
-    "core.travels",
-    "core.persons",
-    "core.counterparts",
-    "core.activities",
-    "core.tasks",
-    "core.detailContracts",
-    "core.contracts",
-    "core.movements",
-    "core.cdps",
-    "django.contrib.admin",
-    "django.contrib.auth",
-    "django.contrib.contenttypes",
-    "django.contrib.sessions",
-    "django.contrib.messages",
-    "django.contrib.staticfiles",
-    ## Third party apps
-    "rest_framework",
+    "drf_yasg",
     "corsheaders",
     ## Local apps
     "core.roles",
@@ -151,7 +126,7 @@ DATABASES = {
         "USER": os.environ.get("DB_USER"),
         "PASSWORD": os.environ.get("DB_PASSWORD"),
         "HOST": os.environ.get("DB_HOST"),
-        "PORT": "5432",
+        "PORT": os.environ.get("DB_PORT"),
     }
 }
 
@@ -162,18 +137,14 @@ DATABASES = {
 AUTH_PASSWORD_VALIDATORS = [
     {
         "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
-        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
     },
     {
-        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
         "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
     },
     {
         "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
-        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
     },
     {
-        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
         "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
     },
 ]

--- a/sgr/urls.py
+++ b/sgr/urls.py
@@ -16,8 +16,24 @@ Including another URLconf
 """
 
 from django.contrib import admin
+from rest_framework import permissions
 from django.urls import path
 from django.urls import include
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+
+schema_view = get_schema_view(
+    openapi.Info(
+        title="SGR API",
+        default_version="v1",
+        description="Documentación de mi API usando Django REST Framework",
+        terms_of_service="https://www.google.com/policies/terms/",
+        contact=openapi.Contact(email="contacto@miempresa.com"),
+        license=openapi.License(name="MIT License"),
+    ),
+    public=True,
+    permission_classes=(permissions.AllowAny,),
+)
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -37,4 +53,10 @@ urlpatterns = [
     path("api/", include("core.contracts.urls")),
     path("api/", include("core.cdps.urls")),
     path("api/", include("core.movements.urls")),
+    # Ruta de la documentación Swagger
+    path(
+        "swagger/", schema_view.with_ui("swagger", cache_timeout=0), name="swagger-ui"
+    ),
+    # También puedes habilitar la documentación en formato redoc:
+    path("redoc/", schema_view.with_ui("redoc", cache_timeout=0), name="redoc-ui"),
 ]

--- a/sgr/urls.py
+++ b/sgr/urls.py
@@ -17,6 +17,7 @@ Including another URLconf
 
 from django.contrib import admin
 from rest_framework import permissions
+from django.views.generic import RedirectView
 from django.urls import path
 from django.urls import include
 from drf_yasg.views import get_schema_view
@@ -36,6 +37,7 @@ schema_view = get_schema_view(
 )
 
 urlpatterns = [
+    path("", RedirectView.as_view(url="/swagger/", permanent=False)),
     path("admin/", admin.site.urls),
     path("api/", include("core.roles.urls")),
     path("api/", include("core.entities.urls")),


### PR DESCRIPTION
### Descripción de los Cambios Realizados

1. **Integración de Swagger**: Se añadió la librería `drf-yasg` para generar la documentación interactiva de la API. Esto permite acceder a un **Swagger UI** en la URL `http://127.0.0.1:8000/swagger/`, donde los desarrolladores pueden explorar los endpoints disponibles, ver sus detalles y realizar pruebas directamente desde la interfaz web.

2. **Creación del archivo README**: Se creó un archivo **README.md** para proporcionar una guía paso a paso sobre cómo configurar y ejecutar el proyecto localmente. El README incluye instrucciones detalladas sobre la instalación de dependencias, la configuración del entorno, la ejecución del servidor y cómo acceder a la documentación de la API a través de Swagger.